### PR TITLE
fix: resizer.className.match is not a function

### DIFF
--- a/src/multipane.js
+++ b/src/multipane.js
@@ -37,7 +37,7 @@ export default {
 
   methods: {
     onMouseDown({ target: resizer, pageX: initialPageX, pageY: initialPageY }) {
-      if (resizer.className && resizer.className.match('multipane-resizer')) {
+      if (resizer.className && typeof resizer.className === 'string' && resizer.className.match('multipane-resizer')) {
         let self = this;
         let { $el: container, layout } = self;
 


### PR DESCRIPTION
when click the svg element，throw Error: resizer.className.match is not a function
```javascript
console.info(resizer.className)
SVGAnimatedString {baseVal: "", animVal: ""}
```